### PR TITLE
Feature/move fields to db

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 
 resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.4")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.9")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0-M5")
 

--- a/src/main/resources/evolutions/default/13.sql
+++ b/src/main/resources/evolutions/default/13.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+
+alter table "application_form_section" add column "fields" JSONB not null default '[]';
+
+# --- !Downs
+
+alter table "application_form_section" drop column "fields";

--- a/src/main/resources/evolutions/default/14.sql
+++ b/src/main/resources/evolutions/default/14.sql
@@ -1,0 +1,30 @@
+# --- !Ups
+
+update "application_form_section"
+set fields = '[{"name": "title", "type": "text", "isNumeric": false}]'
+where "section_number" = 1;
+
+update "application_form_section"
+set fields = '[{"name": "provisionalDate", "type": "dateWithDays", "allowPast":false, "minValue":1, "maxValue":2}]'
+where "section_number" = 2;
+
+update "application_form_section"
+set fields = '[{"name": "eventObjectives", "type": "textArea"}]'
+where "section_number" = 3;
+
+update "application_form_section"
+set fields = '[{"name": "topicAndSpeaker", "type": "textArea"}]'
+where "section_number" = 4;
+
+update "application_form_section"
+set fields = '[{"name": "eventAudience", "type": "textArea"}]'
+where "section_number" = 5;
+
+update "application_form_section"
+set fields = '[{"name": "", "type": "costList"}]'
+where "section_number" = 6;
+
+
+# --- !Downs
+
+update "application_form_section" set fields = '[]';

--- a/src/main/resources/evolutions/default/14.sql
+++ b/src/main/resources/evolutions/default/14.sql
@@ -5,7 +5,7 @@ set fields = '[{"name": "title", "type": "text", "isNumeric": false}]'
 where "section_number" = 1;
 
 update "application_form_section"
-set fields = '[{"name": "provisionalDate", "type": "dateWithDays", "allowPast":false, "minValue":1, "maxValue":2}]'
+set fields = '[{"name": "provisionalDate", "type": "dateWithDays", "allowPast":false, "minValue":1, "maxValue":9}]'
 where "section_number" = 2;
 
 update "application_form_section"

--- a/src/main/scala/rifs/business/models/ApplicationFormRow.scala
+++ b/src/main/scala/rifs/business/models/ApplicationFormRow.scala
@@ -1,7 +1,5 @@
 package rifs.business.models
 
-import play.api.libs.json.JsObject
-
 case class ApplicationFormId(id: Long) extends AnyVal
 
 case class ApplicationFormSectionId(id: Long) extends AnyVal

--- a/src/main/scala/rifs/business/models/ApplicationFormRow.scala
+++ b/src/main/scala/rifs/business/models/ApplicationFormRow.scala
@@ -1,12 +1,20 @@
 package rifs.business.models
 
+import play.api.libs.json.JsArray
+
 case class ApplicationFormId(id: Long) extends AnyVal
 
 case class ApplicationFormSectionId(id: Long) extends AnyVal
 
 case class ApplicationFormQuestionId(id: Long) extends AnyVal
 
-case class ApplicationFormSectionRow(id: ApplicationFormSectionId, applicationFormId: ApplicationFormId, sectionNumber: Int, title: String)
+case class ApplicationFormSectionRow(
+                                      id: ApplicationFormSectionId,
+                                      applicationFormId: ApplicationFormId,
+                                      sectionNumber: Int,
+                                      title: String,
+                                      fields: JsArray
+                                    )
 
 case class ApplicationFormRow(id: ApplicationFormId, opportunityId: OpportunityId)
 

--- a/src/main/scala/rifs/business/restmodels/ApplicationForm.scala
+++ b/src/main/scala/rifs/business/restmodels/ApplicationForm.scala
@@ -1,6 +1,6 @@
 package rifs.business.restmodels
 
-import play.api.libs.json.JsObject
+import play.api.libs.json.JsArray
 import rifs.business.models.{ApplicationFormId, OpportunityId}
 
 case class Question(key: String, text: String, description: Option[String], helpText: Option[String])
@@ -9,6 +9,6 @@ case class ApplicationFormSection(
                                    sectionNumber: Int,
                                    title: String,
                                    questions: Seq[Question],
-                                   fields: Seq[JsObject] = Seq())
+                                   fields: JsArray)
 
 case class ApplicationForm(id: ApplicationFormId, opportunityId: OpportunityId, sections: Seq[ApplicationFormSection])

--- a/src/main/scala/rifs/business/restmodels/ApplicationForm.scala
+++ b/src/main/scala/rifs/business/restmodels/ApplicationForm.scala
@@ -1,9 +1,14 @@
 package rifs.business.restmodels
 
+import play.api.libs.json.JsObject
 import rifs.business.models.{ApplicationFormId, OpportunityId}
 
 case class Question(key: String, text: String, description: Option[String], helpText: Option[String])
 
-case class ApplicationFormSection(sectionNumber: Int, title: String, questions: Seq[Question])
+case class ApplicationFormSection(
+                                   sectionNumber: Int,
+                                   title: String,
+                                   questions: Seq[Question],
+                                   fields: Seq[JsObject] = Seq())
 
 case class ApplicationForm(id: ApplicationFormId, opportunityId: OpportunityId, sections: Seq[ApplicationFormSection])

--- a/src/main/scala/rifs/business/slicks/modules/ApplicationFormModule.scala
+++ b/src/main/scala/rifs/business/slicks/modules/ApplicationFormModule.scala
@@ -1,13 +1,19 @@
 package rifs.business.slicks.modules
 
+import com.github.tminglei.slickpg.{ExPostgresDriver, PgDateSupportJoda, PgPlayJsonSupport}
+import play.api.libs.json.JsArray
 import rifs.business.models._
 import rifs.business.slicks.support.DBBinding
 import rifs.slicks.gen.IdType
 
 trait ApplicationFormModule {
-  self: DBBinding with OpportunityModule =>
+  self:  ExPostgresDriver with PgPlayJsonSupport with PgDateSupportJoda with DBBinding with PlayJsonMappers with OpportunityModule =>
 
-  import driver.api._
+  object pgApi extends API with JsonImplicits with JodaDateTimeImplicits
+
+  override val pgjson = "jsonb"
+
+  import pgApi._
 
   implicit def ApplicationFormQuestionIdMapper: BaseColumnType[ApplicationFormQuestionId] = MappedColumnType.base[ApplicationFormQuestionId, Long](_.id, ApplicationFormQuestionId)
 
@@ -54,7 +60,9 @@ trait ApplicationFormModule {
 
     def title = column[String]("title", O.Length(255))
 
-    def * = (id, applicationFormId, sectionNumber, title) <> (ApplicationFormSectionRow.tupled, ApplicationFormSectionRow.unapply)
+    def fields = column[JsArray]("fields")
+
+    def * = (id, applicationFormId, sectionNumber, title, fields) <> (ApplicationFormSectionRow.tupled, ApplicationFormSectionRow.unapply)
   }
 
   lazy val applicationFormSectionTable = TableQuery[ApplicationFormSectionTable]
@@ -75,5 +83,5 @@ trait ApplicationFormModule {
 
   lazy val applicationFormTable = TableQuery[ApplicationFormTable]
 
-  def schema: driver.DDL = applicationFormQuestionTable.schema ++ applicationFormSectionTable.schema ++ applicationFormTable.schema
+  //def schema: driver.DDL = applicationFormQuestionTable.schema ++ applicationFormSectionTable.schema ++ applicationFormTable.schema
 }

--- a/src/main/scala/rifs/business/slicks/modules/ApplicationModule.scala
+++ b/src/main/scala/rifs/business/slicks/modules/ApplicationModule.scala
@@ -2,36 +2,19 @@ package rifs.business.slicks.modules
 
 import com.github.tminglei.slickpg.{ExPostgresDriver, PgDateSupportJoda, PgPlayJsonSupport}
 import org.joda.time.LocalDateTime
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.JsObject
 import rifs.business.models._
 import rifs.business.slicks.support.DBBinding
 import rifs.slicks.gen.IdType
-import slick.jdbc.JdbcType
-import slick.lifted.Rep
+
 import scala.language.implicitConversions
 
 trait ApplicationModule {
-  self: ExPostgresDriver with PgPlayJsonSupport with PgDateSupportJoda with DBBinding with ApplicationFormModule =>
+  self: ExPostgresDriver with PgPlayJsonSupport with PgDateSupportJoda with DBBinding with ApplicationFormModule with PlayJsonMappers =>
 
   object PostgresAPI extends API with JsonImplicits with JodaDateTimeImplicits
 
   override val pgjson = "jsonb"
-
-  implicit val playJsonTypeMapper: JdbcType[JsObject] =
-    new GenericJdbcType[JsObject](
-      pgjson,
-      (v) => Json.parse(v).as[JsObject],
-      (v) => Json.stringify(v),
-      zero = JsObject(Seq()),
-      hasLiteralForm = false
-    )
-
-  implicit def playJsonColumnExtensionMethods(c: Rep[JsObject]): JsonColumnExtensionMethods[JsObject, JsObject] = {
-    new JsonColumnExtensionMethods[JsObject, JsObject](c)
-  }
-  implicit def playJsonOptionColumnExtensionMethods(c: Rep[Option[JsObject]]): JsonColumnExtensionMethods[JsObject, Option[JsObject]] = {
-    new JsonColumnExtensionMethods[JsObject, Option[JsObject]](c)
-  }
 
   import PostgresAPI._
 

--- a/src/main/scala/rifs/business/slicks/modules/PlayJsonMappers.scala
+++ b/src/main/scala/rifs/business/slicks/modules/PlayJsonMappers.scala
@@ -1,0 +1,27 @@
+package rifs.business.slicks.modules
+
+import com.github.tminglei.slickpg.{ExPostgresDriver, PgPlayJsonSupport}
+import play.api.libs.json.{JsArray, JsObject, Json}
+import slick.jdbc.JdbcType
+
+trait PlayJsonMappers {
+  self: ExPostgresDriver with PgPlayJsonSupport =>
+
+  implicit val playJsObjectTypeMapper: JdbcType[JsObject] =
+    new GenericJdbcType[JsObject](
+      pgjson,
+      (v) => Json.parse(v).as[JsObject],
+      (v) => Json.stringify(v),
+      zero = JsObject(Seq()),
+      hasLiteralForm = false
+    )
+
+  implicit val playJsArrayTypeMapper: JdbcType[JsArray] =
+    new GenericJdbcType[JsArray](
+      pgjson,
+      (v) => Json.parse(v).as[JsArray],
+      (v) => Json.stringify(v),
+      zero = JsArray(),
+      hasLiteralForm = false
+    )
+}

--- a/src/main/scala/rifs/business/tables/ApplicationFormTables.scala
+++ b/src/main/scala/rifs/business/tables/ApplicationFormTables.scala
@@ -2,11 +2,12 @@ package rifs.business.tables
 
 import javax.inject.Inject
 
+import com.github.tminglei.slickpg.{ExPostgresDriver, PgDateSupportJoda, PgPlayJsonSupport}
 import play.api.db.slick.DatabaseConfigProvider
 import rifs.business.data.ApplicationFormOps
 import rifs.business.models._
 import rifs.business.restmodels.{ApplicationForm, ApplicationFormSection, Question}
-import rifs.business.slicks.modules.{ApplicationFormModule, OpportunityModule}
+import rifs.business.slicks.modules.{ApplicationFormModule, OpportunityModule, PlayJsonMappers}
 import rifs.business.slicks.support.DBBinding
 import slick.backend.DatabaseConfig
 import slick.driver.JdbcProfile
@@ -17,6 +18,10 @@ class ApplicationFormTables @Inject()(dbConfigProvider: DatabaseConfigProvider)(
   extends ApplicationFormModule
     with OpportunityModule
     with DBBinding
+    with ExPostgresDriver
+    with PgPlayJsonSupport
+    with PgDateSupportJoda
+    with PlayJsonMappers
     with ApplicationFormOps {
 
   override val dbConfig: DatabaseConfig[JdbcProfile] = dbConfigProvider.get[JdbcProfile]
@@ -74,7 +79,7 @@ object ApplicationFormExtractors {
     val (sections, questions) = sectionRows.unzip
     val ps = sections.distinct.map { s =>
       val qs = questions.flatten.filter(_.applicationFormSectionId == s.id).map(q => Question(q.key, q.text, q.description, q.helpText))
-      s.id -> ApplicationFormSection(s.sectionNumber, s.title, qs)
+      s.id -> ApplicationFormSection(s.sectionNumber, s.title, qs, s.fields)
     }
     Map(ps: _*)
   }

--- a/src/main/scala/rifs/business/tables/ApplicationTables.scala
+++ b/src/main/scala/rifs/business/tables/ApplicationTables.scala
@@ -12,15 +12,23 @@ import rifs.business.controllers.JsonHelpers
 import rifs.business.data.{ApplicationDetails, ApplicationOps}
 import rifs.business.models._
 import rifs.business.restmodels.{Application, ApplicationSection}
-import rifs.business.slicks.modules.{ApplicationFormModule, ApplicationModule, OpportunityModule}
+import rifs.business.slicks.modules.{ApplicationFormModule, ApplicationModule, OpportunityModule, PlayJsonMappers}
 import rifs.business.slicks.support.DBBinding
 import slick.backend.DatabaseConfig
 import slick.driver.JdbcProfile
 
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.{ExecutionContext, Future}
 
 class ApplicationTables @Inject()(dbConfigProvider: DatabaseConfigProvider)(implicit ec: ExecutionContext)
-  extends ApplicationOps with ApplicationModule with DBBinding with ApplicationFormModule with OpportunityModule with ExPostgresDriver with PgPlayJsonSupport with PgDateSupportJoda {
+  extends ApplicationOps
+    with ApplicationModule
+    with DBBinding
+    with ApplicationFormModule
+    with OpportunityModule
+    with ExPostgresDriver
+    with PgPlayJsonSupport
+    with PgDateSupportJoda
+    with PlayJsonMappers {
   override val dbConfig: DatabaseConfig[JdbcProfile] = dbConfigProvider.get[JdbcProfile]
 
   import PostgresAPI._
@@ -121,7 +129,7 @@ class ApplicationTables @Inject()(dbConfigProvider: DatabaseConfigProvider)(impl
 
   override def clearSectionCompletedDate(id: ApplicationId, sectionNumber: Int): Future[Int] = {
     fetchAppWithSection(id, sectionNumber).flatMap {
-      case Some((app, Some(section))) =>  db.run(appSectionC(id, sectionNumber).update(section.copy(completedAt = None)))
+      case Some((app, Some(section))) => db.run(appSectionC(id, sectionNumber).update(section.copy(completedAt = None)))
       case _ => Future.successful(0)
     }
   }

--- a/src/test/scala/rifs/business/tables/ApplicationFormTablesTest.scala
+++ b/src/test/scala/rifs/business/tables/ApplicationFormTablesTest.scala
@@ -1,6 +1,7 @@
 package rifs.business.tables
 
 import org.scalatest.{Matchers, OptionValues, WordSpecLike}
+import play.api.libs.json.JsArray
 import rifs.business.models._
 
 class ApplicationFormTablesTest extends WordSpecLike with Matchers with OptionValues {
@@ -9,7 +10,7 @@ class ApplicationFormTablesTest extends WordSpecLike with Matchers with OptionVa
     "build a section with two questions" in {
       val afId = ApplicationFormId(1)
       val afsId = ApplicationFormSectionId(1)
-      val afs = ApplicationFormSectionRow(afsId, afId, 1, "x")
+      val afs = ApplicationFormSectionRow(afsId, afId, 1, "x", JsArray())
       val q1 = ApplicationFormQuestionRow(ApplicationFormQuestionId(1), afsId, "x.a", "text 1", None, None)
       val q2 = ApplicationFormQuestionRow(ApplicationFormQuestionId(2), afsId, "x.a", "text 1", None, None)
 


### PR DESCRIPTION
Extends the database and REST model to hold descriptions of fields for a form section. This needs to be merged prior to the corresponding PR on `rifs-frontend-play`