### PR TITLE
Feature/1345 amend opportunity dates

### DIFF
--- a/src/main/resources/evolutions/default/17.sql
+++ b/src/main/resources/evolutions/default/17.sql
@@ -1,0 +1,23 @@
+# --- !Ups
+
+# --- Add maxWords values to the text and textArea fields
+
+update "application_form_section"
+set fields = '[{"name": "title", "type": "text", "isNumeric": false, "maxWords": 20}]'
+where "section_number" = 1;
+
+update "application_form_section"
+set fields = '[{"name": "eventObjectives", "type": "textArea", "maxWords": 500}]'
+where "section_number" = 3;
+
+update "application_form_section"
+set fields = '[{"name": "topicAndSpeaker", "type": "textArea", "maxWords": 500}]'
+where "section_number" = 4;
+
+update "application_form_section"
+set fields = '[{"name": "eventAudience", "type": "textArea", "maxWords": 500}]'
+where "section_number" = 5;
+
+# --- !Downs
+
+# --- No need for any downs - the extra maxWords attributes will be ignored

--- a/src/main/resources/evolutions/default/17.sql
+++ b/src/main/resources/evolutions/default/17.sql
@@ -1,6 +1,6 @@
 # --- !Ups
 
-# --- Add maxWords values to the text and textArea fields
+--- Add maxWords values to the text and textArea fields
 
 update "application_form_section"
 set fields = '[{"name": "title", "type": "text", "isNumeric": false, "maxWords": 20}]'
@@ -20,4 +20,4 @@ where "section_number" = 5;
 
 # --- !Downs
 
-# --- No need for any downs - the extra maxWords attributes will be ignored
+--- No need for any downs - the extra maxWords attributes will be ignored

--- a/src/main/resources/evolutions/default/17.sql
+++ b/src/main/resources/evolutions/default/17.sql
@@ -24,6 +24,10 @@ alter table "application_form_section" add column "section_type" varchar(50) not
 update "application_form_section" set "section_type" = 'list' where "section_number" = 6;
 update "application_form_section" set "fields" = '[]' where "section_number" = 6;
 
+alter table "opportunity" drop column duration;
+alter table "opportunity" drop column duration_units;
+alter table "opportunity" add column end_date varchar(255);
+
 # --- !Downs
 
 --- the extra maxWords attributes will be ignored

--- a/src/main/resources/evolutions/default/17.sql
+++ b/src/main/resources/evolutions/default/17.sql
@@ -18,6 +18,18 @@ update "application_form_section"
 set fields = '[{"name": "eventAudience", "type": "textArea", "maxWords": 500}]'
 where "section_number" = 5;
 
+alter table "application_form_section" drop column "started";
+
+alter table "application_form_section" add column "section_type" varchar(50) not null default 'form';
+update "application_form_section" set "section_type" = 'list' where "section_number" = 6;
+update "application_form_section" set "fields" = '[]' where "section_number" = 6;
+
 # --- !Downs
 
---- No need for any downs - the extra maxWords attributes will be ignored
+--- the extra maxWords attributes will be ignored
+--- the started column was never used to no need to restore it
+
+alter table "application_form_section" drop column "section_type";
+update "application_form_section"
+set fields = '[{"name": "", "type": "costList"}]'
+where "section_number" = 6;

--- a/src/main/resources/routes
+++ b/src/main/resources/routes
@@ -2,6 +2,7 @@
 GET           /opportunity/open                                     rifs.business.controllers.OpportunityController.getOpen
 GET           /opportunity/open/summaries                           rifs.business.controllers.OpportunityController.getOpenSummaries
 GET           /opportunity/:id                                      rifs.business.controllers.OpportunityController.byId(id: OpportunityId)
+PUT           /opportunity/:id/summary                              rifs.business.controllers.OpportunityController.updateSummary(id: OpportunityId)
 GET           /opportunity/:id/application_form                     rifs.business.controllers.ApplicationFormController.forOpportunity(id: OpportunityId)
 GET           /application_form/:id                                 rifs.business.controllers.ApplicationFormController.byId(id: ApplicationFormId)
 

--- a/src/main/scala/rifs/business/controllers/OpportunityController.scala
+++ b/src/main/scala/rifs/business/controllers/OpportunityController.scala
@@ -7,8 +7,9 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, Controller}
 import rifs.business.data.OpportunityOps
 import rifs.business.models.OpportunityId
+import rifs.business.restmodels.OpportunitySummary
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 class OpportunityController @Inject()(val cached: Cached, opportunities: OpportunityOps)(implicit val ec: ExecutionContext) extends Controller with ControllerUtils {
 
@@ -28,5 +29,11 @@ class OpportunityController @Inject()(val cached: Cached, opportunities: Opportu
     Action.async {
       opportunities.open.map(os => Ok(Json.toJson(os)))
     }
+  }
+
+  def updateSummary(id: OpportunityId) = Action.async(parse.json[OpportunitySummary]) { implicit request =>
+    val summary = request.body
+    if (summary.id != id) Future.successful(BadRequest(s"id provided on url was ${id.id}, but does not match id of body: ${summary.id.id}"))
+    else opportunities.updateSummary(request.body).map(_ => NoContent)
   }
 }

--- a/src/main/scala/rifs/business/data/OpportunityOps.scala
+++ b/src/main/scala/rifs/business/data/OpportunityOps.scala
@@ -16,5 +16,7 @@ trait OpportunityOps {
   def open: Future[Set[Opportunity]]
 
   def openSummaries: Future[Set[Opportunity]]
+
+  def updateSummary(summary: OpportunitySummary): Future[Int]
 }
 

--- a/src/main/scala/rifs/business/models/ApplicationFormRow.scala
+++ b/src/main/scala/rifs/business/models/ApplicationFormRow.scala
@@ -13,6 +13,7 @@ case class ApplicationFormSectionRow(
                                       applicationFormId: ApplicationFormId,
                                       sectionNumber: Int,
                                       title: String,
+                                      sectionType: String,
                                       fields: JsArray
                                     )
 

--- a/src/main/scala/rifs/business/models/OpportunityRow.scala
+++ b/src/main/scala/rifs/business/models/OpportunityRow.scala
@@ -14,8 +14,7 @@ case class OpportunityRow(
                            id: OpportunityId,
                            title: String,
                            startDate: String,
-                           duration: Option[Int],
-                           durationUnits: Option[String],
+                           endDate: Option[String],
                            value: BigDecimal,
                            valueUnits: String
                          )

--- a/src/main/scala/rifs/business/restmodels/ApplicationForm.scala
+++ b/src/main/scala/rifs/business/restmodels/ApplicationForm.scala
@@ -9,6 +9,7 @@ case class ApplicationFormSection(
                                    sectionNumber: Int,
                                    title: String,
                                    questions: Seq[Question],
+                                   sectionType: String,
                                    fields: JsArray)
 
 case class ApplicationForm(id: ApplicationFormId, opportunityId: OpportunityId, sections: Seq[ApplicationFormSection])

--- a/src/main/scala/rifs/business/restmodels/Opportunity.scala
+++ b/src/main/scala/rifs/business/restmodels/Opportunity.scala
@@ -12,17 +12,17 @@ case class Opportunity(
                         id: OpportunityId,
                         title: String,
                         startDate: String,
-                        duration: Option[OpportunityDuration],
+                        endDate: Option[String],
                         value: OpportunityValue,
                         description: Set[OpportunityDescriptionSection]
                       ) {
-  def summary: OpportunitySummary = OpportunitySummary(id, title, startDate, duration, value)
+  def summary: OpportunitySummary = OpportunitySummary(id, title, startDate, endDate, value)
 }
 
 case class OpportunitySummary(
                                id: OpportunityId,
                                title: String,
                                startDate: String,
-                               duration: Option[OpportunityDuration],
+                               endDate: Option[String],
                                value: OpportunityValue
                              )

--- a/src/main/scala/rifs/business/slicks/modules/ApplicationFormModule.scala
+++ b/src/main/scala/rifs/business/slicks/modules/ApplicationFormModule.scala
@@ -7,7 +7,7 @@ import rifs.business.slicks.support.DBBinding
 import rifs.slicks.gen.IdType
 
 trait ApplicationFormModule {
-  self:  ExPostgresDriver with PgPlayJsonSupport with PgDateSupportJoda with DBBinding with PlayJsonMappers with OpportunityModule =>
+  self: ExPostgresDriver with PgPlayJsonSupport with PgDateSupportJoda with DBBinding with PlayJsonMappers with OpportunityModule =>
 
   object pgApi extends API with JsonImplicits with JodaDateTimeImplicits
 
@@ -60,9 +60,11 @@ trait ApplicationFormModule {
 
     def title = column[String]("title", O.Length(255))
 
+    def sectionType = column[String]("section_type", O.Length(50))
+
     def fields = column[JsArray]("fields")
 
-    def * = (id, applicationFormId, sectionNumber, title, fields) <> (ApplicationFormSectionRow.tupled, ApplicationFormSectionRow.unapply)
+    def * = (id, applicationFormId, sectionNumber, title, sectionType, fields) <> (ApplicationFormSectionRow.tupled, ApplicationFormSectionRow.unapply)
   }
 
   lazy val applicationFormSectionTable = TableQuery[ApplicationFormSectionTable]

--- a/src/main/scala/rifs/business/slicks/modules/OpportunityModule.scala
+++ b/src/main/scala/rifs/business/slicks/modules/OpportunityModule.scala
@@ -44,15 +44,13 @@ trait OpportunityModule {
 
     def startDate = column[String]("start_date", O.Length(255))
 
-    def duration = column[Option[Int]]("duration")
-
-    def durationUnits = column[Option[String]]("duration_units", O.Length(255))
+    def endDate = column[Option[String]]("end_date", O.Length(255))
 
     def value = column[BigDecimal]("value", O.SqlType("decimal(9, 2)"))
 
     def valueUnits = column[String]("value_units", O.Length(255))
 
-    def * = (id, title, startDate, duration, durationUnits, value, valueUnits) <> (OpportunityRow.tupled, OpportunityRow.unapply)
+    def * = (id, title, startDate, endDate, value, valueUnits) <> (OpportunityRow.tupled, OpportunityRow.unapply)
   }
 
   lazy val opportunityTable = TableQuery[OpportunityTable]

--- a/src/main/scala/rifs/business/tables/ApplicationFormTables.scala
+++ b/src/main/scala/rifs/business/tables/ApplicationFormTables.scala
@@ -79,7 +79,7 @@ object ApplicationFormExtractors {
     val (sections, questions) = sectionRows.unzip
     val ps = sections.distinct.map { s =>
       val qs = questions.flatten.filter(_.applicationFormSectionId == s.id).map(q => Question(q.key, q.text, q.description, q.helpText))
-      s.id -> ApplicationFormSection(s.sectionNumber, s.title, qs, s.fields)
+      s.id -> ApplicationFormSection(s.sectionNumber, s.title, qs, s.sectionType, s.fields)
     }
     Map(ps: _*)
   }

--- a/src/main/scala/rifs/business/tables/OpportunityExtractors.scala
+++ b/src/main/scala/rifs/business/tables/OpportunityExtractors.scala
@@ -20,7 +20,7 @@ object OpportunityExtractors {
         o.id,
         o.title,
         o.startDate,
-        durationFor(o),
+        o.endDate,
         OpportunityValue(o.value, o.valueUnits),
         sectionsFor(o, sectionRows.toSet))
     }.toSet
@@ -34,9 +34,6 @@ object OpportunityExtractors {
     OpportunityDescriptionSection(s.sectionNumber, s.title, s.text)
   }
 
-  def durationFor(opp: OpportunityRow): Option[OpportunityDuration] = {
-    (opp.duration |@| opp.durationUnits).map(OpportunityDuration.apply)
-  }
 
   /**
     * useful for extracting from leftJoin results where the second item in the pair is represented as

--- a/src/main/scala/rifs/business/tables/OpportunityTables.scala
+++ b/src/main/scala/rifs/business/tables/OpportunityTables.scala
@@ -5,7 +5,7 @@ import javax.inject.Inject
 import play.api.db.slick.DatabaseConfigProvider
 import rifs.business.data.OpportunityOps
 import rifs.business.models.{OpportunityId, OpportunityRow}
-import rifs.business.restmodels.{Opportunity, OpportunityValue}
+import rifs.business.restmodels.{Opportunity, OpportunitySummary, OpportunityValue}
 import rifs.business.slicks.modules.OpportunityModule
 import rifs.business.slicks.support.DBBinding
 import slick.backend.DatabaseConfig
@@ -31,7 +31,13 @@ class OpportunityTables @Inject()(dbConfigProvider: DatabaseConfigProvider)(impl
   }
 
   override def openSummaries: Future[Set[Opportunity]] = db.run(opportunityTableC.result).map { os =>
-    os.map(o => Opportunity(o.id, o.title, o.startDate, durationFor(o), OpportunityValue(o.value, o.valueUnits), Set())).toSet
+    os.map(o => Opportunity(o.id, o.title, o.startDate, o.endDate, OpportunityValue(o.value, o.valueUnits), Set())).toSet
+  }
+
+
+  override def updateSummary(summary: OpportunitySummary): Future[Int] = db.run {
+    val row = OpportunityRow(summary.id, summary.title, summary.startDate, summary.endDate, summary.value.amount, summary.value.unit)
+    byIdC(summary.id).update(row)
   }
 
   /** ****************************

--- a/src/main/scala/rifs/business/validation/ValidationRules.scala
+++ b/src/main/scala/rifs/business/validation/ValidationRules.scala
@@ -1,0 +1,10 @@
+package rifs.business.validation
+
+object ValidationRules {
+
+  val rule1 = "startDate is mandatory"
+  val rule2 = "date(startDate.day, startDate.month, startDate.year) is not before today"
+  val rule3 = "title is no longer than 20 words"
+  val rule4 = "provisionalDate.days is between 1 and 9"
+
+}

--- a/src/test/scala/rifs/business/NotificationsTest.scala
+++ b/src/test/scala/rifs/business/NotificationsTest.scala
@@ -72,7 +72,7 @@ object NotificationsTestData {
   val (appOpsAndSection, appOps) = {
     val APP_FORM_ID = ApplicationFormId(1)
     val OPPORTUNITY_ID = OpportunityId(1)
-    val opp = OpportunityRow(OPPORTUNITY_ID, "oz1", "", None, None, 0, "")
+    val opp = OpportunityRow(OPPORTUNITY_ID, "oz1", "", None, 0, "")
 
     val appDetails = ApplicationDetails(
       ApplicationRow(Some(APP_ID), APP_FORM_ID),

--- a/src/test/scala/rifs/business/tables/ApplicationFormTablesTest.scala
+++ b/src/test/scala/rifs/business/tables/ApplicationFormTablesTest.scala
@@ -10,7 +10,7 @@ class ApplicationFormTablesTest extends WordSpecLike with Matchers with OptionVa
     "build a section with two questions" in {
       val afId = ApplicationFormId(1)
       val afsId = ApplicationFormSectionId(1)
-      val afs = ApplicationFormSectionRow(afsId, afId, 1, "x", JsArray())
+      val afs = ApplicationFormSectionRow(afsId, afId, 1, "x", "form", JsArray())
       val q1 = ApplicationFormQuestionRow(ApplicationFormQuestionId(1), afsId, "x.a", "text 1", None, None)
       val q2 = ApplicationFormQuestionRow(ApplicationFormQuestionId(2), afsId, "x.a", "text 1", None, None)
 


### PR DESCRIPTION
Changes to support saving an opportunity summary (needed by the various forms used in the manage opp flow to edit properties of the opportunity) and updates the database to remove the opportunity duration and add the end date. Because this changes the shape of the opportunity json it is dependent on the corresponding PR from the frontend.