### PR TITLE
Add automated support for developers for using the docker postgres image

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,26 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/79c11c91bca345b9857902f637c46d2e)](https://www.codacy.com/app/doug/rifs-business?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=UKGovernmentBEIS/rifs-business&amp;utm_campaign=Badge_Grade)
 [![CircleCI](https://circleci.com/gh/UKGovernmentBEIS/rifs-business.svg?style=svg)](https://circleci.com/gh/UKGovernmentBEIS/rifs-business)
 
+
+### Dependencies
+
+This application requires the postgres database.  You can either install this yourself 
+ or use docker-compose to get the [latest docker hub postgres image.](https://hub.docker.com/_/postgres/)
+ 
+ Some basic docker command lines:
+ 
+```
+ # Bring postgres up (and build the image if needed) on localhost:5432
+ docker-compose up -d
+
+```
+
+```
+ # shutdown postgres
+ docker-compose stop
+```
+
+```
+ # remove the container
+ docker-compose rm   
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+    postgres:
+      build: docker/postgres
+      ports:
+        - "5432:5432"

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,0 +1,5 @@
+# Setup postgres for developer usage with a `rifs` db and a `rifs` user
+FROM postgres:alpine
+MAINTAINER js@ovix.co.uk
+COPY ./init-user-db.sh /docker-entrypoint-initdb.d/
+EXPOSE 5432

--- a/docker/postgres/init-user-db.sh
+++ b/docker/postgres/init-user-db.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+    CREATE USER rifs;
+    CREATE DATABASE rifs;
+    GRANT ALL PRIVILEGES ON DATABASE rifs TO rifs;
+EOSQL

--- a/docker/postgres/init-user-db.sh
+++ b/docker/postgres/init-user-db.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+psql -v ON_ERROR_STOP=1 --host=localhost --username postgres <<-EOSQL
     CREATE USER rifs;
     CREATE DATABASE rifs;
     GRANT ALL PRIVILEGES ON DATABASE rifs TO rifs;

--- a/docker/postgres/init-user-db.sh
+++ b/docker/postgres/init-user-db.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-psql -v ON_ERROR_STOP=1 --host=localhost --username postgres <<-EOSQL
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
     CREATE USER rifs;
     CREATE DATABASE rifs;
     GRANT ALL PRIVILEGES ON DATABASE rifs TO rifs;


### PR DESCRIPTION

* use the alpine image to minimise download size
* binds postgres to localhost:5432 (as the app expects)
* creates the rifs database and rifs
