### PR TITLE
I've added a `/reset` endpoint that the frontend can use to support t…

### DIFF
--- a/src/main/resources/development.logger.xml
+++ b/src/main/resources/development.logger.xml
@@ -10,8 +10,8 @@
   <logger name="slick"                                                     level="INFO"  />
   <logger name="slick.ast"                                                 level="INFO"  />
   <logger name="slick.compiler"                                            level="INFO"  />
-  <logger name="slick.jdbc.JdbcBackend.statement"                          level="DEBUG" />
-  <logger name="slick.jdbc.StatementInvoker.result"                        level="DEBUG"  />
+  <logger name="slick.jdbc.JdbcBackend.statement"                          level="INFO" />
+  <logger name="slick.jdbc.StatementInvoker.result"                        level="INFO"  />
   <logger name="slick.jdbc.JdbcBackend.benchmark"                          level="INFO"  />
 
   <root level="DEBUG">

--- a/src/main/resources/development.logger.xml
+++ b/src/main/resources/development.logger.xml
@@ -10,8 +10,8 @@
   <logger name="slick"                                                     level="INFO"  />
   <logger name="slick.ast"                                                 level="INFO"  />
   <logger name="slick.compiler"                                            level="INFO"  />
-  <logger name="slick.jdbc.JdbcBackend.statement"                          level="INFO" />
-  <logger name="slick.jdbc.StatementInvoker.result"                        level="INFO"  />
+  <logger name="slick.jdbc.JdbcBackend.statement"                          level="DEBUG" />
+  <logger name="slick.jdbc.StatementInvoker.result"                        level="DEBUG"  />
   <logger name="slick.jdbc.JdbcBackend.benchmark"                          level="INFO"  />
 
   <root level="DEBUG">

--- a/src/main/resources/routes
+++ b/src/main/resources/routes
@@ -38,6 +38,9 @@ DELETE        /application/:id/section/:num/item/:itemNum            rifs.busine
 # Submit application
 POST          /application/:id/submit                                rifs.business.controllers.ApplicationController.submit(id: ApplicationId)
 
+# utility endpoints for testing
+POST          /reset                                                 rifs.business.controllers.UtilityController.reset()
+
 # Health check
 GET           /ping                                                  rifs.business.controllers.HealthCheckController.ping()
 GET           /version                                               rifs.business.controllers.HealthCheckController.version()

--- a/src/main/scala/rifs/business/controllers/UtilityController.scala
+++ b/src/main/scala/rifs/business/controllers/UtilityController.scala
@@ -1,0 +1,19 @@
+package rifs.business.controllers
+
+import javax.inject.Inject
+
+import play.api.mvc.{Action, Controller}
+import rifs.business.actions.OpportunityAction
+import rifs.business.data.{ApplicationOps, OpportunityOps}
+
+import scala.concurrent.ExecutionContext
+
+class UtilityController @Inject()(applications: ApplicationOps, opportunities: OpportunityOps, OpportunityAction: OpportunityAction)(implicit val ec: ExecutionContext) extends Controller {
+
+  def reset() = Action.async {
+    for {
+      _ <- applications.deleteAll
+      _ <- opportunities.reset()
+    } yield NoContent
+  }
+}

--- a/src/main/scala/rifs/business/data/OpportunityOps.scala
+++ b/src/main/scala/rifs/business/data/OpportunityOps.scala
@@ -27,5 +27,7 @@ trait OpportunityOps {
   def duplicate(id: OpportunityId): Future[Option[OpportunityId]]
 
   def saveSectionDescription(id: OpportunityId, sectionNo: Int, description: Option[String]): Future[Int]
+
+  def reset(): Future[Unit]
 }
 

--- a/src/main/scala/rifs/business/tables/OpportunityTables.scala
+++ b/src/main/scala/rifs/business/tables/OpportunityTables.scala
@@ -110,6 +110,15 @@ class OpportunityTables @Inject()(val dbConfigProvider: DatabaseConfigProvider, 
   lazy val sectionC = Compiled(sectionQ _)
 
   override def saveSectionDescription(id: OpportunityId, sectionNo: Int, description: Option[String]): Future[Int] = db.run {
-    sectionQ(id, sectionNo).map(r=> r.text).update(description)
+    sectionQ(id, sectionNo).map(r => r.text).update(description)
+  }
+
+  override def reset(): Future[Unit] = {
+    val action = for {
+      _ <- opportunityTable.filter(_.id > OpportunityId(1)).delete
+      _ <- sqlu"alter sequence opportunity_id_seq restart with 2"
+    } yield ()
+
+    db.run(action.transactionally)
   }
 }


### PR DESCRIPTION
…esting. It will remove all applications and also any opportunities other than the first one that is created by the test data evolutions. It will also reset the sequence that is used to generate opportunity ids so that new opportunities will be numbered from 2.