### PR TITLE
Removed the slickGen sub-project and am now pulling that stuff in as …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import de.heikoseeberger.sbtheader.CommentStyleMapping._
 import de.heikoseeberger.sbtheader.license.MIT
 import sbtbuildinfo.BuildInfoPlugin.autoImport._
 
-
 name := "rifs-business"
 
 headers in ThisBuild := createFrom(MIT, "2016", "Department of Business, Energy and Industrial Strategy")
@@ -10,13 +9,12 @@ git.useGitDescribe in ThisBuild := true
 
 scalaVersion in ThisBuild := "2.11.8"
 
-lazy val slickGen = (project in file("slickGen"))
-  .settings(libraryDependencies ++= Seq(
-    "com.wellfactored" %% "property-info" % "1.0.0"
-  ))
-  .enablePlugins(AutomateHeaderPlugin)
-  .enablePlugins(GitVersioning)
-  .enablePlugins(GitBranchPrompt)
+enablePlugins(PlayScala)
+disablePlugins(PlayLayoutPlugin)
+enablePlugins(GitVersioning)
+enablePlugins(GitBranchPrompt)
+enablePlugins(BuildInfoPlugin)
+enablePlugins(AutomateHeaderPlugin)
 
 val SLICK_PG_VERSION = "0.14.3"
 
@@ -27,48 +25,38 @@ val slickpgDependencies = Seq(
   "com.github.tminglei" %% "slick-pg_joda-time" % SLICK_PG_VERSION
 )
 
-lazy val `rifs-business` = (project in file("."))
-  .dependsOn(slickGen).aggregate(slickGen)
-  .enablePlugins(PlayScala)
-  .disablePlugins(PlayLayoutPlugin)
-  .enablePlugins(GitVersioning)
-  .enablePlugins(GitBranchPrompt)
-  .enablePlugins(BuildInfoPlugin)
-  .settings(
-    libraryDependencies ++= Seq(
-      cache,
-      "com.wellfactored" %% "play-bindings" % "1.1.0",
-      "com.github.melrief" %% "pureconfig" % "0.1.6",
-      "org.postgresql" % "postgresql" % "9.4.1211",
-      "com.typesafe.slick" %% "slick" % "3.1.1",
-      "com.typesafe.play" %% "play-slick" % "2.0.0",
-      "com.typesafe.play" %% "play-slick-evolutions" % "2.0.0",
-      "com.typesafe.play" %% "play-mailer" % "5.0.0",
-      "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % "test"
-
-    ),
-    libraryDependencies ++= slickpgDependencies,
-    PlayKeys.devSettings := Seq("play.server.http.port" -> "9100"),
-    routesImport ++= Seq(
-      "rifs.business.models._",
-      "com.wellfactored.playbindings.ValueClassUrlBinders._"
-    ),
-    javaOptions := Seq(
-      "-Dconfig.file=src/main/resources/development.application.conf",
-      "-Dlogger.file=src/main/resources/development.logger.xml"
-    ),
-    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
-    buildInfoPackage := "rifs.business.buildinfo",
-    buildInfoOptions ++= Seq(BuildInfoOption.ToJson, BuildInfoOption.BuildTime)
-  )
-  .enablePlugins(AutomateHeaderPlugin)
-
-fork in Test in ThisBuild := true
-testForkedParallel in ThisBuild := true
-
-libraryDependencies in ThisBuild ++= Seq(
+libraryDependencies ++= Seq(
+  "com.wellfactored" %% "play-bindings" % "1.1.0",
+  "com.wellfactored" % "slick-gen_2.11" % "0.0.4",
+  "com.github.melrief" %% "pureconfig" % "0.1.6",
+  "org.postgresql" % "postgresql" % "9.4.1211",
+  "com.typesafe.slick" %% "slick" % "3.1.1",
+  "com.typesafe.play" %% "play-slick" % "2.0.0",
+  "com.typesafe.play" %% "play-slick-evolutions" % "2.0.0",
+  "com.typesafe.play" %% "play-mailer" % "5.0.0",
   "joda-time" % "joda-time" % "2.9.4",
   "org.joda" % "joda-convert" % "1.7",
   "com.wellfactored" %% "value-wrapper" % "1.1.0",
-  "org.scalatest" %% "scalatest" % "2.2.0" % Test
+  "org.scalatest" %% "scalatest" % "2.2.0" % Test,
+  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % "test")
+
+libraryDependencies ++= slickpgDependencies
+
+PlayKeys.devSettings := Seq("play.server.http.port" -> "9100")
+
+routesImport ++= Seq(
+  "rifs.business.models._",
+  "com.wellfactored.playbindings.ValueClassUrlBinders._"
 )
+
+javaOptions := Seq(
+  "-Dconfig.file=src/main/resources/development.application.conf",
+  "-Dlogger.file=src/main/resources/development.logger.xml"
+)
+
+buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion)
+buildInfoPackage := "rifs.business.buildinfo"
+buildInfoOptions ++= Seq(BuildInfoOption.ToJson, BuildInfoOption.BuildTime)
+
+fork in Test in ThisBuild := true
+testForkedParallel in ThisBuild := true

--- a/src/main/scala/rifs/business/slicks/modules/ApplicationFormModule.scala
+++ b/src/main/scala/rifs/business/slicks/modules/ApplicationFormModule.scala
@@ -1,10 +1,10 @@
 package rifs.business.slicks.modules
 
 import com.github.tminglei.slickpg.{ExPostgresDriver, PgDateSupportJoda, PgPlayJsonSupport}
+import com.wellfactored.slickgen.IdType
 import play.api.libs.json.JsArray
 import rifs.business.models._
 import rifs.business.slicks.support.DBBinding
-import rifs.slicks.gen.IdType
 
 trait ApplicationFormModule extends PlayJsonMappers{
   self:  DBBinding with ExPostgresDriver with PgDateSupportJoda with PgPlayJsonSupport with OpportunityModule =>

--- a/src/main/scala/rifs/business/slicks/modules/ApplicationModule.scala
+++ b/src/main/scala/rifs/business/slicks/modules/ApplicationModule.scala
@@ -5,7 +5,7 @@ import org.joda.time.DateTime
 import play.api.libs.json.JsObject
 import rifs.business.models._
 import rifs.business.slicks.support.DBBinding
-import rifs.slicks.gen.IdType
+import com.wellfactored.slickgen.IdType
 
 import scala.language.implicitConversions
 

--- a/src/main/scala/rifs/business/slicks/modules/OpportunityModule.scala
+++ b/src/main/scala/rifs/business/slicks/modules/OpportunityModule.scala
@@ -3,7 +3,7 @@ package rifs.business.slicks.modules
 import org.joda.time.DateTime
 import rifs.business.models._
 import rifs.business.slicks.support.DBBinding
-import rifs.slicks.gen.IdType
+import com.wellfactored.slickgen.IdType
 
 trait OpportunityModule {
   self: DBBinding =>

--- a/src/main/scala/rifs/business/slicks/modulesdefs/ApplicationFormModuleDef.scala
+++ b/src/main/scala/rifs/business/slicks/modulesdefs/ApplicationFormModuleDef.scala
@@ -1,7 +1,7 @@
 package rifs.business.slicks.modulesdefs
 
+import com.wellfactored.slickgen._
 import rifs.business.models.{ApplicationFormQuestionRow, ApplicationFormRow, ApplicationFormSectionRow}
-import rifs.slicks.gen.{ModuleDefinition, ModuleSpec}
 
 object ApplicationFormModuleDef extends ModuleDefinition {
   val spec = ModuleSpec("ApplicationFormModule")

--- a/src/main/scala/rifs/business/slicks/modulesdefs/ApplicationModuleDef.scala
+++ b/src/main/scala/rifs/business/slicks/modulesdefs/ApplicationModuleDef.scala
@@ -1,7 +1,7 @@
 package rifs.business.slicks.modulesdefs
 
+import com.wellfactored.slickgen.{ModuleDefinition, ModuleSpec}
 import rifs.business.models._
-import rifs.slicks.gen.{ModuleDefinition, ModuleSpec}
 
 object ApplicationModuleDef extends ModuleDefinition {
   val spec = ModuleSpec("ApplicationModule")

--- a/src/main/scala/rifs/business/slicks/modulesdefs/OpportunityModuleDef.scala
+++ b/src/main/scala/rifs/business/slicks/modulesdefs/OpportunityModuleDef.scala
@@ -1,7 +1,7 @@
 package rifs.business.slicks.modulesdefs
 
+import com.wellfactored.slickgen.{ModuleDefinition, ModuleSpec}
 import rifs.business.models.{OpportunityRow, SectionRow}
-import rifs.slicks.gen.{ModuleDefinition, ModuleSpec}
 
 object OpportunityModuleDef extends ModuleDefinition {
   val spec = ModuleSpec("OpportunityModule")


### PR DESCRIPTION
…a library. This simplifies the build.sbt somewhat as well, as it's now only a single-project build.